### PR TITLE
modify monitor/alert MonitorService to AlertService

### DIFF
--- a/core/monitor/alert/alert.proto
+++ b/core/monitor/alert/alert.proto
@@ -7,7 +7,7 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "github.com/mwitkow/go-proto-validators/validator.proto";
 
-service MonitorService {
+service AlertService {
   rpc QueryCustomizeMetric (QueryCustomizeMetricRequest) returns (QueryCustomizeMetricResponse) {
     option (google.api.http) = {
       get: "/api/customize/alerts/metrics",


### PR DESCRIPTION
What type of this PR
feature

What this PR does / why we need it:
modify monitor/alert MonitorService to AlertService

Specified Reviewers:
/assign @recallsong