### PR TITLE
add common proto for identity & commitDetail

### DIFF
--- a/common/commit.proto
+++ b/common/commit.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package erda.core.common;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/erda-project/erda-proto-go/common/pb";
+
+message CommitDetail {
+  string commitID = 1;
+  string repo = 2;
+  string repoAddr = 3;
+  string author = 4;
+  string email = 5;
+  google.protobuf.Timestamp time = 6;
+  string comment = 7;
+}

--- a/common/identity.proto
+++ b/common/identity.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package erda.core.common;
+
+option go_package = "github.com/erda-project/erda-proto-go/common/pb";
+
+message IdentityInfo {
+  // UserID is user id. It must be provided in some cases.
+  // Cannot be null if InternalClient is null.
+  // +optional
+  string userID = 1;
+
+  // InternalClient records the internal client, such as: bundle.
+  // Cannot be null if UserID is null.
+  // +optional
+  string internalClient = 2;
+}


### PR DESCRIPTION
Some providers will use these common protos and generated pb structs later.