### PR TITLE
feature:  model definition for observability analysis platform

### DIFF
--- a/oap/common/common.proto
+++ b/oap/common/common.proto
@@ -51,11 +51,12 @@ message Relation {
     // Related trace id . optional
     bytes trace_id = 1;
 
-    // Related resource id
+    // Related resource id . Optional
     string res_id = 2;
 
-    // Related resource type
+    // Related resource type . Optional
     string res_type = 3;
 
+    // Optional
     repeated string resource_keys = 4;
 }

--- a/oap/common/common.proto
+++ b/oap/common/common.proto
@@ -1,0 +1,61 @@
+syntax = "proto3";
+
+// oap ~ Observability Analysis Platform
+package erda.oap.common;
+option go_package = "github.com/erda-project/erda-proto-go/oap/common/pb";
+
+// KeyValue is a key-value pair that is used to store Span attributes, Link
+// attributes, etc.
+message KeyValue {
+    string key = 1;
+    AnyValue value = 2;
+}
+
+// KeyValueList is a list of KeyValue messages. We need KeyValueList as a message
+// since `oneof` in AnyValue does not allow repeated fields. Everywhere else where we need
+// a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
+// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
+// are semantically equivalent.
+message KeyValueList {
+    // A collection of key/value pairs of key-value pairs. The list may be empty (may
+    // contain 0 elements).
+    repeated KeyValue values = 1;
+}
+
+// AnyValue is used to represent any type of attribute value. AnyValue may contain a
+// primitive value such as a string or integer or it may contain an arbitrary nested
+// object containing arrays, key-value lists and primitives.
+message AnyValue {
+    // The value is one of the listed fields. It is valid for all values to be unspecified
+    // in which case this AnyValue is considered to be "null".
+    oneof value {
+      string string_value = 1;
+      bool bool_value = 2;
+      int64 int_value = 3;
+      double double_value = 4;
+      ArrayValue array_value = 5;
+      KeyValueList kvlist_value = 6;
+      bytes bytes_value = 7;
+    }
+}
+
+  // ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
+  // since oneof in AnyValue does not allow repeated fields.
+message ArrayValue {
+    // Array of values. The array may be empty (contain 0 elements).
+    repeated AnyValue values = 1;
+}
+
+message Relation {
+
+    // Related trace id . optional
+    bytes trace_id = 1;
+
+    // Related resource id
+    string res_id = 2;
+
+    // Related resource type
+    string res_type = 3;
+
+    repeated string resource_keys = 4;
+}

--- a/oap/entity/entity.proto
+++ b/oap/entity/entity.proto
@@ -21,7 +21,10 @@ message EntityRow {
 
     KeyValueList row_data = 4;
 
-    fixed64 create_time_unix_nano = 5;
+    // Including label, attributes and resource 
+    map<string, string> attributes = 5;
 
-    fixed64 update_time_unix_nano = 6;
+    fixed64 create_time_unix_nano = 6;
+
+    fixed64 update_time_unix_nano = 7;
 }

--- a/oap/entity/entity.proto
+++ b/oap/entity/entity.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package erda.oap.entity;
+
+option go_package = "github.com/erda-project/erda-proto-go/oap/entity/pb";
+
+import "oap/common/common.proto";
+
+// The Entity data model 
+//   of the observability analysis platform.
+// Unlike time series data, entity data has a unique ID,
+//   and data can be inserted, updated, and deleted according to the unique ID.
+message EntityRow {
+
+    // unique
+    string id = 1;
+
+    string table = 2;
+
+    bytes row_id = 3; 
+
+    KeyValueList row_data = 4;
+
+    fixed64 create_time_unix_nano = 5;
+
+    fixed64 update_time_unix_nano = 6;
+}

--- a/oap/event/event.proto
+++ b/oap/event/event.proto
@@ -28,11 +28,15 @@ message Event {
 
         EVENT_KIND_CONTAINER = 2;
 
-        EVENT_KIND_EXCEPTION = 3;
+        EVENT_KIND_ERDA_PLATFORM = 3;
 
-        EVENT_KIND_SPAN = 4;
+        EVENT_KIND_EXCEPTION = 4;
 
-        EVENT_KIND_CUSTOM = 5;
+        EVENT_KIND_SPAN = 5;
+
+        EVENT_KIND_ALERT = 6;
+
+        EVENT_KIND_CUSTOM = 7;
     }
 
     EventKind kind = 4;

--- a/oap/event/event.proto
+++ b/oap/event/event.proto
@@ -1,0 +1,49 @@
+syntax = "proto3";
+
+package erda.oap.event;
+
+option go_package = "github.com/erda-project/erda-proto-go/oap/event/pb";
+
+import "oap/common/common.proto";
+
+// The event data model 
+//   of the observability analysis platform.
+message Event {
+
+    bytes event_id = 1; 
+
+    // The severity text (also known as level). The original string representation as
+    // it is known at the source. [Optional].
+    // Normal、Warning eg.
+
+    string severity = 2;
+
+    string name = 3;
+
+    enum EventKind {
+
+        EVENT_KIND_SYSTEM = 0;
+
+        EVENT_KIND_KUBERNETES = 1;
+
+        EVENT_KIND_CONTAINER = 2;
+
+        EVENT_KIND_EXCEPTION = 3;
+
+        EVENT_KIND_SPAN = 4;
+
+        EVENT_KIND_CUSTOM = 5;
+    }
+
+    EventKind kind = 4;
+
+    fixed64 time_unix_nano = 5;
+
+    // Store trace and resource pointer
+    Relation relations = 6;
+
+    // Including label, attributes and resource 
+    map<string, string> attributes = 7;
+
+    string message = 8;
+}

--- a/oap/logs/log.proto
+++ b/oap/logs/log.proto
@@ -13,11 +13,11 @@ message Log {
     fixed64 time_unix_nano = 1;
 
     // log source , like contaoner_log, job_log, deploy_log, app_log .
-    string name = 3;
+    string name = 2;
 
     // The severity text (also known as log level). The original string representation as
     // it is known at the source. [Optional].
-    string severity = 2;
+    string severity = 3;
 
     // Store trace and resource pointer
     Relation relations = 4;

--- a/oap/logs/log.proto
+++ b/oap/logs/log.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package erda.oap.logs;
+
+option go_package = "github.com/erda-project/erda-proto-go/oap/logs/pb";
+
+import "oap/common.proto";
+
+// The logging data model 
+//   of the observability analysis platform.
+message Log {
+
+    fixed64 time_unix_nano = 1;
+
+    // log source , like contaoner_log, job_log, deploy_log, app_log .
+    string name = 3;
+
+    // The severity text (also known as log level). The original string representation as
+    // it is known at the source. [Optional].
+    string severity = 2;
+
+    // Store trace and resource pointer
+    Relation relations = 4;
+
+    // Including label, attributes and resource 
+    map<string, string> attributes = 5;
+
+    // Multi data points
+    // The data point can be the original value or the aggregated value 
+    bytes content  = 6;
+}

--- a/oap/metrics/metrics.proto
+++ b/oap/metrics/metrics.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package erda.oap.metrics;
+
+option go_package = "github.com/erda-project/erda-proto-go/oap/metrics/pb";
+
+import "oap/common.proto";
+
+// The metrics data model 
+//   of the observability analysis platform.
+message Metric {
+
+    string name = 1;
+
+    fixed64 time_unix_nano = 2;
+
+    // Store trace and resource pointer
+    Relation relations = 3;
+
+    // Including label, attributes and resource 
+    map<string, string> attributes = 4;
+
+    // Multi data points
+    // The data point can be the original value or the aggregated value 
+    map<string, AnyValue> data_points  = 5;
+}

--- a/oap/trace/trace.proto
+++ b/oap/trace/trace.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+
+package erda.oap.trace;
+
+option go_package = "github.com/erda-project/erda-proto-go/oap/trace/pb";
+
+import "oap/common/common.proto";
+
+// The span data model 
+//   of the observability analysis platform.
+// Trace is calculated by span, stored as metric.
+message Span {
+
+    // A unique identifier for a trace. All spans from the same trace share
+    // the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes
+    // is considered invalid.
+    //
+    // This field is semantically required. Receiver should generate new
+    // random trace_id if empty or invalid trace_id was received.
+    //
+    // This field is required.
+    bytes trace_id = 1;
+
+    // A unique identifier for a span within a trace, assigned when the span
+    // is created. The ID is an 8-byte array. An ID with all zeroes is considered
+    // invalid.
+    //
+    // This field is semantically required. Receiver should generate new
+    // random span_id if empty or invalid span_id was received.
+    //
+    // This field is required.
+    bytes span_id = 2;
+
+
+    // The `span_id` of this span's parent span. If this is a root span, then this
+    // field must be empty. The ID is an 8-byte array.
+    bytes parent_span_id = 3;
+
+    fixed64 strat_time_unix_nano = 4;
+
+    // end_time_unix_nano is the end time of the span. On the client side, this is the time
+    // kept by the local machine where the span execution ends. On the server side, this
+    // is the time when the server application handler stops running.
+    // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
+    //
+    // This field is semantically required and it is expected that end_time >= start_time.
+    fixed64 end_time_unix_nano = 5;
+
+    // A description of the span's operation.
+    //
+    // For example, the name can be a qualified method name or a file name
+    // and a line number where the operation is called. A best practice is to use
+    // the same display name at the same call point in an application.
+    // This makes it easier to correlate spans in different traces.
+    //
+    // This field is semantically required to be set to non-empty string.
+    // When null or empty string received - receiver may use string "name"
+    // as a replacement. There might be smarted algorithms implemented by
+    // receiver to fix the empty span name.
+    //
+    // This field is required.
+    string name = 6;
+
+    // Store trace and resource pointer
+    Relation relations = 7;
+
+    // Including label, attributes and resource 
+    map<string, string> attributes = 8;
+}


### PR DESCRIPTION
The observability analysis platform (oap) is designed to process metrics, logs and trace data, and provide unified processing, storage and query functions for observability data.
Add observability data protocol
- Metrics proto
- Trace proto
- Log proto
- Event proto
- Entity proto