### PR TITLE
update autotest-plan content

### DIFF
--- a/core/dop/autotest/testplan/autotest-plan.proto
+++ b/core/dop/autotest/testplan/autotest-plan.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package erda.core.dop.autotest.testplan;
 option go_package = "github.com/erda-project/erda-proto-go/core/dop/autotest/testplan/pb";
 import "google/api/annotations.proto";
+import "google/protobuf/timestamp.proto";
 
 service TestPlanService {
   rpc UpdateTestPlanByHook (TestPlanUpdateByHookRequest) returns (TestPlanUpdateByHookResponse)  {
@@ -26,10 +27,11 @@ message TestPlanUpdateByHookRequest{
 
 message Content {
   uint64 testPlanID = 1;
-  string executeTime = 2;
+  google.protobuf.Timestamp executeTime = 2;
   double passRate = 3;
-  double executeMinutes = 4;
-  int64 apiTotalNum = 5;
+  int64 apiTotalNum = 4;
+  // time duration of the test plan execution
+  string executeDuration = 5;
 }
 
 message TestPlanUpdateByHookResponse {


### PR DESCRIPTION
change ExecuteTime type to time.time

executeMinutes => ExecuteDuration
ExecuteDuration mean execute time duration, like "00:01:30", 0h, 1m, 30s

**message example**: org.Name/project.Name plan1 测试计划执行完成，接口通过率: 99.00%，接口总数: 100，时长: 00:00:03