### PR TITLE
Fix/execute time

### DIFF
--- a/core/dop/autotest/testplan/autotest-plan.proto
+++ b/core/dop/autotest/testplan/autotest-plan.proto
@@ -27,7 +27,7 @@ message TestPlanUpdateByHookRequest{
 
 message Content {
   uint64 testPlanID = 1;
-  google.protobuf.Timestamp executeTime = 2;
+  string executeTime = 2;
   double passRate = 3;
   int64 apiTotalNum = 4;
   // time duration of the test plan execution

--- a/core/dop/autotest/testplan/autotest-plan.proto
+++ b/core/dop/autotest/testplan/autotest-plan.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package erda.core.dop.autotest.testplan;
 option go_package = "github.com/erda-project/erda-proto-go/core/dop/autotest/testplan/pb";
 import "google/api/annotations.proto";
-import "google/protobuf/timestamp.proto";
 
 service TestPlanService {
   rpc UpdateTestPlanByHook (TestPlanUpdateByHookRequest) returns (TestPlanUpdateByHookResponse)  {


### PR DESCRIPTION
Feature/1.3 execute time

executeTime should be "1970-01-02T00:00:00.000Z"
but in go, it is like "executeTime":{"seconds":1631692755,"nanos":790524572},

so only can use string to translate